### PR TITLE
resolution cutoff now happend before SFC initialization

### DIFF
--- a/rocket/cryo/targets.py
+++ b/rocket/cryo/targets.py
@@ -39,47 +39,23 @@ class LLGloss(torch.nn.Module):
     def __init__(
         self,
         sfc: SFcalculator,
-        mtz_file: str,
+        mtz_file: str | rs.DataSet,
         resol_min=None,
         resol_max=None,
     ) -> None:
         super().__init__()
         self.sfc = sfc
         self.device = sfc.device
-        if isinstance(mtz_file, str):
-            data_dict = cryo_utils.load_tng_data(mtz_file, device=self.device)
+        assert isinstance(mtz_file, str | rs.DataSet), (
+            "mtz_file must be a path to mtz file or rs.DataSet"
+        )
 
-            self.register_buffer("Emean", data_dict["Emean"])
-            self.register_buffer("PHIEmean", data_dict["PHIEmean"])
-            self.register_buffer("Dobs", data_dict["Dobs"])
+        data_dict = cryo_utils.load_tng_data(mtz_file, device=self.device)
 
-        elif isinstance(mtz_file, rs.DataSet):
-            data_dict = mtz_file
+        self.register_buffer("Emean", data_dict["Emean"])
+        self.register_buffer("PHIEmean", data_dict["PHIEmean"])
+        self.register_buffer("Dobs", data_dict["Dobs"])
 
-            self.register_buffer(
-                "Emean",
-                torch.tensor(
-                    data_dict["Emean"].values, dtype=torch.float32, device=self.device
-                ),
-            )
-            self.register_buffer(
-                "PHIEmean",
-                torch.tensor(
-                    data_dict["PHIEmean"].values,
-                    dtype=torch.float32,
-                    device=self.device,
-                ),
-            )
-            self.register_buffer(
-                "Dobs",
-                torch.tensor(
-                    data_dict["Dobs"].values, dtype=torch.float32, device=self.device
-                ),
-            )
-        else:
-            raise TypeError(
-                f"mtz_file must be path or rs.DataSet, got {type(mtz_file)} instead"
-            )
         if resol_min is None:
             resol_min = min(self.sfc.dHKL)
 

--- a/rocket/cryo/utils.py
+++ b/rocket/cryo/utils.py
@@ -34,12 +34,15 @@ def downsample_data(mtz_path, downsample_ratio: int):
 def load_tng_data(tng_file, device=None):
     if device is None:
         device = utils.try_gpu()
-    tng = utils.load_mtz(tng_file).dropna()
+    if isinstance(tng_file, str):
+        tng = utils.load_mtz(tng_file).dropna()
+    elif isinstance(tng_file, rs.DataSet):
+        tng = tng_file.dropna()
 
     # Generate PhaserTNG tensors
-    emean = torch.tensor(tng["Emean"].values, device=device)
-    phi_emean = torch.tensor(tng["PHIEmean"].values, device=device)
-    dobs = torch.tensor(tng["Dobs"].values, device=device)
+    emean = torch.tensor(tng["Emean"].values, dtype=torch.float32, device=device)
+    phi_emean = torch.tensor(tng["PHIEmean"].values, dtype=torch.float32, device=device)
+    dobs = torch.tensor(tng["Dobs"].values, dtype=torch.float32, device=device)
 
     data_dict = {
         "Emean": emean,

--- a/rocket/refinement_cryoem.py
+++ b/rocket/refinement_cryoem.py
@@ -78,6 +78,14 @@ def run_cryoem_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmen
             )
             mtz_file = cryo_utils.downsample_data(mtz_file, config.downsample_ratio)
 
+    # Apply resolution cutoff to the reflection file
+    if config.min_resolution is not None or config.max_resolution is not None:
+        mtz_file = rk_utils.apply_resolution_cutoff(
+            mtz_file,
+            min_resolution=config.min_resolution,
+            max_resolution=config.max_resolution,
+        )
+
     # Initialize SFC
     cryo_sfc = cryo_sf.initial_cryoSFC(
         input_pdb, mtz_file, "Emean", "PHIEmean", device, N_BINS

--- a/rocket/refinement_xray.py
+++ b/rocket/refinement_xray.py
@@ -105,6 +105,14 @@ def run_xray_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmentC
             SIGMA_TRUE = False
 
     ############ 2. Initializations ############
+
+    # Apply resolution cutoff to the reflection file
+    if config.min_resolution is not None or config.max_resolution is not None:
+        tng_file = rk_utils.apply_resolution_cutoff(
+            tng_file,
+            min_resolution=config.min_resolution,
+            max_resolution=config.max_resolution,
+        )
     # Initialize SFC
     sfc = llg_sf.initial_SFC(
         input_pdb,

--- a/rocket/utils.py
+++ b/rocket/utils.py
@@ -190,3 +190,36 @@ def get_params_path():
         raise ValueError("Please set OPENFOLD_RESOURCES environment variable")
     params_path = os.path.join(resources_path, "params")
     return params_path
+
+
+def apply_resolution_cutoff(
+    dataset: rs.DataSet | str,
+    min_resolution: float = None,
+    max_resolution: float = None,
+):
+    """
+    Apply resolution cutoff to a dataset.
+
+    Args:
+        dataset (rs.DataSet | str): The dataset to filter, can be a path to an MTZ file
+            or an rs.DataSet object.
+        min_resolution (float): Minimum resolution to keep.
+        max_resolution (float): Maximum resolution to keep.
+
+    Returns:
+        rs.DataSet: Filtered dataset with applied resolution cutoff.
+    """
+    if isinstance(dataset, str):
+        dataset = rs.read_mtz(dataset)
+
+    dataset.compute_dHKL(inplace=True)
+    if max_resolution is None:
+        max_resolution = dataset.dHKL.max()
+    if min_resolution is None:
+        min_resolution = dataset.dHKL.min()
+    filtered_dataset = dataset[
+        (dataset.dHKL >= (min_resolution - 1e-4))
+        & (dataset.dHKL <= (max_resolution + 1e-4))
+    ].copy()
+
+    return filtered_dataset

--- a/rocket/xtal/utils.py
+++ b/rocket/xtal/utils.py
@@ -3,6 +3,7 @@ Functions relating to sigmaa calculation and refinement
 """
 
 import numpy as np
+import reciprocalspaceship as rs
 import torch
 
 from rocket import utils
@@ -454,7 +455,10 @@ def find_bin_dHKL(dHKLs, bin_labels):
 def load_tng_data(tng_file, device=None):
     if device is None:
         device = utils.try_gpu()
-    tng = utils.load_mtz(tng_file).dropna()
+    if isinstance(tng_file, str):
+        tng = utils.load_mtz(tng_file).dropna()
+    elif isinstance(tng_file, rs.DataSet):
+        tng = tng_file.dropna()
     # Generate PhaserTNG tensors
     eps = torch.tensor(tng["EPS"].values, device=device)
     centric = torch.tensor(tng["CENT"].values, device=device).bool()


### PR DESCRIPTION
Made changes to address issue #44.

Note that the memory bottleneck in ROCKET has two components. The first is the evoformer in OpenFold, which depends solely on the number of residues (N_residues). The second is the Fmodel in SFC, which is determined by the number of atoms (N_atoms) and the number of reflections (N_hkls).

This change affects only the second component.

In tests with case 1lj5:
-  Without a `min_resolution` setting, peak memory usage was about 27.4 GB.
-  With `min_resolution` set to 2.5 Å, peak memory usage dropped to about 22.2 GB, matching the bottleneck set by the evoformer.

Need a code review by @alisiafadini 
