### PR TITLE
New feature: construct Bfactors from fast RSCC calculation on the fly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [ # Optional: PyPI classifiers, see https://pypi.org/classifiers/
 ]
 
 dependencies = [
-    "scikit-bio",
+    "scikit-bio<=0.6.3",
     "loguru",
     "SFcalculator-torch>=0.2.2",
     "matplotlib",

--- a/rocket/coordinates.py
+++ b/rocket/coordinates.py
@@ -190,7 +190,7 @@ def pose_train_lbfgs_quat(
         qs + trans_vecs,
         lr=lr,
         line_search_fn="strong_wolfe",
-        tolerance_change=1e-3,
+        tolerance_change=1e-9,
         max_iter=1,
     )
     propose_rmcoms = []

--- a/rocket/coordinates.py
+++ b/rocket/coordinates.py
@@ -683,6 +683,184 @@ def align_tensors(tensor1, centroid1, centroid2, rotation_matrix):
     return aligned_tensor1
 
 
+def weighted_kabsch_svd(P, Q, weights=None):
+    """
+    Computes the optimal rotation matrix that minimizes the weighted RMSD
+    between two sets of corresponding points P and Q using SVD.
+
+    Args:
+        P (np.ndarray): Reference points, shape (N, 3).
+        Q (np.ndarray): Points to align to P, shape (N, 3).
+        weights (np.ndarray, optional): Weights for each point, shape (N,).
+
+    Returns:
+        np.ndarray: Optimal rotation matrix (3, 3).
+    """
+    if P.shape[0] < 3:
+        raise ValueError("Need at least 3 points for stable alignment")
+
+    # Center the point clouds using weighted average
+    centroid_P = np.average(P, axis=0, weights=weights)
+    centroid_Q = np.average(Q, axis=0, weights=weights)
+    P_centered = P - centroid_P
+    Q_centered = Q - centroid_Q
+
+    # Compute weighted covariance matrix
+    H = Q_centered.T @ np.diag(weights if weights is not None else 1) @ P_centered
+
+    # Perform SVD
+    try:
+        U, _, Vt = np.linalg.svd(H)
+    except np.linalg.LinAlgError:
+        return np.identity(3)  # Fallback for unstable SVD
+
+    # Calculate rotation matrix R
+    R = Vt.T @ U.T
+
+    # Handle reflection case (ensures a right-handed coordinate system)
+    if np.linalg.det(R) < 0:
+        Vt[-1, :] *= -1
+        R = Vt.T @ U.T
+
+    return R
+
+
+def iterative_kabsch_alignment(
+    moving_tensor,
+    ref_tensor,
+    cra_name,
+    weights=None,
+    exclude_res=None,
+    domain_segs=None,
+    cutoff=2.0,
+    cycles=5,
+):
+    """
+    Performs Kabsch alignment with iterative outlier rejection on protein structures.
+
+    Args:
+        moving_tensor (torch.Tensor): Coords to move, shape [n_points, 3].
+        ref_tensor (torch.Tensor): Reference coords, shape [n_points, 3].
+        cra_name (List[str]): Chain-residue-atom identifiers, [n_points].
+        weights (torch.Tensor|np.ndarray, optional): Weights for the alignment.
+        exclude_res (List[int], optional): Residue IDs to exclude.
+        domain_segs (List[int], optional): Residue IDs defining domain boundaries.
+        cutoff (float): Distance cutoff in Angstroms for outlier rejection.
+        cycles (int): Max number of refinement cycles. Set to 0 for a single
+                      alignment without outlier rejection.
+
+    Returns:
+        torch.Tensor: The aligned moving_tensor, shape [n_points, 3].
+    """
+    # --- 1. Initial Filtering Setup ---
+    backbone_bool = np.array([i.split("-")[-1] in ["N", "CA", "C"] for i in cra_name])
+    resid = np.array([int(i.split("-")[1]) for i in cra_name])
+    minid, maxid = resid.min(), resid.max()
+
+    if exclude_res is None:
+        residue_bool = (resid > minid + 4) & (resid < maxid - 4)
+    else:
+        residue_bool = np.isin(resid, exclude_res, invert=True)
+
+    # --- 2. Define Domains ---
+    if domain_segs is None:
+        domain_ranges = [[minid, maxid + 1]]
+    else:
+        domain_ranges = []
+        start = minid
+        sorted_segs = sorted(domain_segs)
+        for i, seg in enumerate(sorted_segs):
+            domain_ranges.append([start, seg])
+            start = seg
+            if i == len(sorted_segs) - 1:
+                domain_ranges.append([start, maxid + 1])
+
+    # --- 3. Process Each Domain ---
+    aligned_pos = moving_tensor.clone()
+    for domain_start, domain_end_notin in domain_ranges:
+        domain_bool = (resid >= domain_start) & (resid < domain_end_notin)
+        working_set_mask = backbone_bool & residue_bool & domain_bool
+
+        if not working_set_mask.any():
+            continue
+
+        moving_align_coords = utils.assert_numpy(moving_tensor)[working_set_mask]
+        ref_align_coords = utils.assert_numpy(ref_tensor)[working_set_mask]
+        if moving_align_coords.shape[0] < 3:
+            continue
+
+        align_weights = (
+            utils.assert_numpy(weights)[working_set_mask]
+            if weights is not None
+            else None
+        )  # noqa: E501
+
+        # --- 4. Iterative Alignment for the Current Domain ---
+        inlier_indices = np.arange(moving_align_coords.shape[0])
+        final_R = np.identity(3)
+
+        for cycle in range(cycles + 1):
+            P_iter = ref_align_coords[inlier_indices]
+            Q_iter = moving_align_coords[inlier_indices]
+            w_iter = (
+                align_weights[inlier_indices] if align_weights is not None else None
+            )  # noqa: E501
+            try:
+                R_iter = weighted_kabsch_svd(P_iter, Q_iter, weights=w_iter)
+            except ValueError:
+                break
+            final_R = R_iter
+
+            if cycle == cycles:
+                break
+
+            # Apply transform and find new inliers
+            centroid_Q = np.average(Q_iter, axis=0, weights=w_iter)
+            centroid_P = np.average(P_iter, axis=0, weights=w_iter)
+            t_iter = centroid_P - final_R @ centroid_Q
+
+            transformed_align_coords = (final_R @ moving_align_coords.T).T + t_iter
+            distances = np.linalg.norm(
+                ref_align_coords - transformed_align_coords, axis=1
+            )  # noqa: E501
+            new_inlier_indices = np.where(distances < cutoff)[0]
+
+            if len(new_inlier_indices) < 3 or np.array_equal(
+                inlier_indices, new_inlier_indices
+            ):  # noqa: E501
+                break
+            inlier_indices = new_inlier_indices
+        # --- 5. Apply Final Transformation to the Entire Domain ---
+        P_final = ref_align_coords[inlier_indices]
+        Q_final = moving_align_coords[inlier_indices]
+        w_final = align_weights[inlier_indices] if align_weights is not None else None
+
+        # Calculate final centroids based on the final set of inliers
+        final_centroid_moving = np.average(Q_final, axis=0, weights=w_final)
+        final_centroid_ref = np.average(P_final, axis=0, weights=w_final)
+        # Get all points in the domain and convert components to tensors
+        moving_domain_tensor = moving_tensor[domain_bool]
+        R_torch = torch.tensor(
+            final_R, dtype=moving_tensor.dtype, device=moving_tensor.device
+        )
+        centroid1_torch = torch.tensor(
+            final_centroid_moving,
+            dtype=moving_tensor.dtype,
+            device=moving_tensor.device,
+        )
+        centroid2_torch = torch.tensor(
+            final_centroid_ref, dtype=moving_tensor.dtype, device=moving_tensor.device
+        )
+
+        # Use your function to apply the final transformation
+        aligned_domain_tensor = align_tensors(
+            moving_domain_tensor, centroid1_torch, centroid2_torch, R_torch
+        )
+        aligned_pos[domain_bool] = aligned_domain_tensor
+
+    return aligned_pos
+
+
 def weighted_kabsch(
     moving_tensor,
     ref_tensor,

--- a/rocket/cryo/structurefactors.py
+++ b/rocket/cryo/structurefactors.py
@@ -51,6 +51,6 @@ def initial_cryoSFC(
     # note @ Aug 27 by MH: treat Emean as Fmean
     # Ep = sfcalculator.calc_Ec(sfcalculator.Fprotein_HKL)
     # sfcalculator.Fprotein_HKL = Ep
-    sfcalculator.get_scales_adam()
+    sfcalculator.get_scales_adam(sub_ratio=1.0)
 
     return sfcalculator

--- a/rocket/refinement_cryoem.py
+++ b/rocket/refinement_cryoem.py
@@ -104,7 +104,7 @@ def run_cryoem_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmen
         input_pdb, mtz_file, "Emean", "PHIEmean", device, N_BINS
     )
     # prepare reusable variables for RSCC calculation
-    gridsize = mtz_file.get_size_for_hkl(sample_rate=3.0)
+    gridsize = mtz_file.get_reciprocal_grid_size(sample_rate=3.0)
     Rg = torch.tensor(
         rk_utils.g_function_np(2 * cryo_sfc.dmin, 1 / cryo_sfc.dHKL), device=device
     )
@@ -430,7 +430,7 @@ def run_cryoem_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmen
                 uc_volume,
             )
             atom_cc = rk_utils.interpolate_grid_points(
-                ccmap, cryo_llgloss_rbr.atom_pos_frac.cpu().numpy()
+                ccmap, cryo_llgloss_rbr.sfc.atom_pos_frac.cpu().numpy()
             )
             rscc_bfactor = torch.tensor(
                 rk_utils.get_b_from_CC(atom_cc, cryo_llgloss_rbr.sfc.dmin),

--- a/rocket/refinement_cryoem.py
+++ b/rocket/refinement_cryoem.py
@@ -122,12 +122,13 @@ def run_cryoem_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmen
     cutoff1 = np.quantile(init_pos_bfactor.cpu().numpy(), 0.3)
     cutoff2 = cutoff1 * 1.5
     bfactor_weights = rk_utils.weighting_torch(init_pos_bfactor, cutoff1, cutoff2)
+    bfactor_weights = bfactor_weights / torch.sum(bfactor_weights)
 
     # residue_numbers = [int(name.split("-")[1]) for name in cra_calphas_list]
 
     # LLG initialization
     cryo_llgloss = cryo_targets.LLGloss(cryo_sfc, mtz_file)
-    cryo_llgloss_rbr = cryo_targets.LLGloss(cryo_sfc, mtz_file)
+    cryo_llgloss_rbr = cryo_targets.LLGloss(sfc_rbr, mtz_file)
 
     # Model initialization
     version_to_class = {

--- a/rocket/refinement_cryoem.py
+++ b/rocket/refinement_cryoem.py
@@ -118,7 +118,10 @@ def run_cryoem_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmen
 
     # Use initial pos B factor instead of best pos B factor for weighted L2
     init_pos_bfactor = cryo_sfc.atom_b_iso.clone()
-    bfactor_weights = rk_utils.weighting_torch(init_pos_bfactor, cutoff2=20.0)
+    # Ad hoc settings for B-factor weighting cutoffs
+    cutoff1 = np.quantile(init_pos_bfactor.cpu().numpy(), 0.3)
+    cutoff2 = cutoff1 * 1.5
+    bfactor_weights = rk_utils.weighting_torch(init_pos_bfactor, cutoff1, cutoff2)
 
     # residue_numbers = [int(name.split("-")[1]) for name in cra_calphas_list]
 

--- a/rocket/refinement_utils.py
+++ b/rocket/refinement_utils.py
@@ -372,12 +372,18 @@ def position_alignment(
 
     # MH @ Sep 10 2024, temp edits to convert weighted kabsch to cutoff kabsch
     if reference_bfactor is None:
-        weights = rk_utils.weighting(rk_utils.assert_numpy(pseudo_Bs))
+        pseudoB_np = rk_utils.assert_numpy(pseudo_Bs)
+        cutoff1 = np.quantile(pseudoB_np, 0.3)
+        cutoff2 = cutoff1 * 1.5
+        weights = rk_utils.weighting(pseudoB_np, cutoff1, cutoff2)
     else:
         assert reference_bfactor.shape == pseudo_Bs.shape, (
             "Reference bfactor should have same shape as model bfactor!"
         )
-        weights = rk_utils.weighting(rk_utils.assert_numpy(reference_bfactor))
+        reference_bfactor_np = rk_utils.assert_numpy(reference_bfactor)
+        cutoff1 = np.quantile(reference_bfactor_np, 0.3)
+        cutoff2 = cutoff1 * 1.5
+        weights = rk_utils.weighting(reference_bfactor_np, cutoff1, cutoff2)
     # plddts_np = rk_utils.assert_numpy(plddts)
     # weights = np.ones_like(plddts_np)
     # weights[plddts_np < 85.0] = 1e-5

--- a/rocket/refinement_utils.py
+++ b/rocket/refinement_utils.py
@@ -382,7 +382,7 @@ def position_alignment(
     # weights = np.ones_like(plddts_np)
     # weights[plddts_np < 85.0] = 1e-5
 
-    aligned_xyz = rk_coordinates.weighted_kabsch(
+    aligned_xyz = rk_coordinates.iterative_kabsch_alignment(
         xyz_orth_sfc,
         best_pos,
         cra_name,

--- a/rocket/utils.py
+++ b/rocket/utils.py
@@ -363,15 +363,26 @@ def get_b_from_CC(CC_values, d_min):
     CC_trunc = (CC_values + 0.001 + np.abs(CC_values - 0.001)) / 2
 
     # Flex arrays can't be used as exponents, so work around this with logs
+    # TODO: verify the constants here
+    # Randy's note: In case you’re wondering, the magic numbers and the magic formula
+    # come from some things I did in Mathematica.
+    # I worked out a formula that converts RMSD to an expected CC.
     u1 = np.exp(np.log(0.188779) * CC_trunc)
     u2 = np.exp(2.21742 * CC_trunc * np.log(CC_trunc))
     u3 = np.exp(0.777046 * np.tan(CC_trunc) * np.log(CC_trunc) * CC_trunc)
     b_values_from_CC = (
         np.power(d_min, 2) * 134.024 * np.power(0.213624 - u1 * u2 - 0.359452 * u3, 2)
     )
+    # Previous Approach, now we dropped
     # Truncate B-values at a maximum of 350 above minimum
     # 350 was chosen semi-arbitrarily as a point at which the sigmaA curve drops
     # below 0.1 at 6A, so that data beyond 6A will have little influence
-    bmax = np.min(b_values_from_CC) + 350.0
-    b_values_from_CC = (b_values_from_CC + bmax - np.abs(b_values_from_CC - bmax)) / 2
+    # bmax = np.min(b_values_from_CC) + 350.0
+    # b_values_from_CC = (b_values_from_CC + bmax - np.abs(b_values_from_CC - bmax)) / 2
+
+    # Do normal truncation instead, as Randy Suggested
+    bmin = np.min(b_values_from_CC)
+    b_values_from_CC = b_values_from_CC - bmin
+    bmax = 999.0
+    b_values_from_CC = np.clip(b_values_from_CC, 0.0, bmax)
     return b_values_from_CC

--- a/rocket/utils.py
+++ b/rocket/utils.py
@@ -4,7 +4,9 @@ from functools import partial
 import numpy as np
 import reciprocalspaceship as rs
 import torch
+from scipy.interpolate import RegularGridInterpolator
 from SFC_Torch import PDBParser
+from SFC_Torch.mask import reciprocal_grid
 
 
 def plddt2pseudoB_np(plddts):
@@ -223,3 +225,153 @@ def apply_resolution_cutoff(
     ].copy()
 
     return filtered_dataset
+
+
+def g_function_np(R: float, s: np.ndarray) -> np.ndarray:
+    """
+    Calculates the Fourier transform of a sphere (g-function) using
+    spherical Bessel function in NumPy.
+
+    Args:
+        R (float): The radius of the sphere.
+        s (np.ndarray): An array of reciprocal space vector magnitudes (1/d).
+
+    Returns:
+        np.ndarray: The calculated g-function values.
+    """
+    # Ensure s is a numpy array
+    if not isinstance(s, np.ndarray):
+        s = np.array(s, dtype=np.float64)
+
+    # Create an output array initialized with the value for s=0
+    g_vals = np.ones_like(s)
+
+    # Identify non-zero s values to avoid division by zero
+    nonzero_mask = np.abs(s) > 1e-9
+
+    # Calculate the g-function only for non-zero s
+    s_nonzero = s[nonzero_mask]
+    x = 2 * np.pi * R * s_nonzero
+    g_vals_nonzero = 3 * (np.sin(x) - x * np.cos(x)) / np.power(x, 3)
+
+    # Place the calculated values into the output array
+    g_vals[nonzero_mask] = g_vals_nonzero
+
+    return g_vals
+
+
+def map2fourier(map_grid, HKL_arrays):
+    rs_grid = torch.fft.ifftn(map_grid, dim=(-3, -2, -1), norm="forward")
+    tuple_index = tuple(torch.tensor(HKL_arrays.T, device=rs_grid.device, dtype=int))
+    Frs = rs_grid[tuple_index]
+    return Frs
+
+
+def fourier2map(Fs, HKL_arrays, gridsize):
+    rs_grid = reciprocal_grid(HKL_arrays, Fs, gridsize)
+    map_grid = torch.real(torch.fft.fftn(rs_grid, dim=(-3, -2, -1)))
+    return map_grid
+
+
+def interpolate_grid_points(map_grid, frac_coords_batch, method="linear"):
+    """
+    Interpolates values on a 3D grid at a batch of fractional coordinates.
+
+    Args:
+        map_grid (np.ndarray): A 3D NumPy array representing the data grid.
+        frac_coords_batch (np.ndarray): A 2D NumPy array of shape (N, 3),
+                                        where N is the number of points and
+                                        each row contains the [x, y, z]
+                                        fractional coordinates.
+
+    Returns:
+        np.ndarray: A 1D NumPy array of shape (N,) containing the
+                    interpolated values for each point in the batch.
+    """
+    # 1. Define the grid points (indices) for each dimension.
+    x = np.arange(map_grid.shape[0])
+    y = np.arange(map_grid.shape[1])
+    z = np.arange(map_grid.shape[2])
+
+    # 2. Create the interpolator object.
+    interpolator = RegularGridInterpolator(
+        (x, y, z), map_grid, method=method, bounds_error=False, fill_value=None
+    )
+
+    # 3. Convert the batch of fractional coordinates to grid coordinates.
+    grid_shape = np.array(map_grid.shape)
+    frac_coords_batch = frac_coords_batch % 1.0
+    point_coords_batch = frac_coords_batch * (grid_shape - 1)
+
+    # 4. Get the interpolated values for the entire batch of points.
+    interpolated_values = interpolator(point_coords_batch)
+
+    return interpolated_values
+
+
+def get_rscc_from_Fmap(
+    Fcalc: torch.Tensor,
+    Fmap: torch.Tensor,
+    HKL_arrays: np.ndarray,
+    gridsize: list[int],
+    Rg: torch.Tensor,
+    unitcell_volume: float,
+) -> float:
+    assert len(Fcalc) == len(HKL_arrays)
+    assert len(Fmap) == len(HKL_arrays)
+    assert len(Rg) == len(HKL_arrays)
+
+    map1 = fourier2map(Fcalc, HKL_arrays, gridsize)
+    map1_normed = (map1 - map1.mean()) / map1.std()
+
+    map2 = fourier2map(Fmap, HKL_arrays, gridsize)
+    map2_normed = (map2 - map2.mean()) / map2.std()
+
+    productmap = map1_normed * map2_normed
+    Fproductmap = map2fourier(productmap, HKL_arrays)
+    Fproductmap_smooth = Fproductmap * Rg
+
+    productmap_smooth = fourier2map(Fproductmap_smooth, HKL_arrays, gridsize)
+    productmap_smooth_norm = 2.0 * productmap_smooth / unitcell_volume
+
+    variance1_map = map1_normed * map1_normed
+    Fvmap1 = map2fourier(variance1_map, HKL_arrays)
+    Fvmap1_smoothed = Fvmap1 * Rg
+    vmap1_smoothed = fourier2map(Fvmap1_smoothed, HKL_arrays, gridsize)
+    vmap1_smoothed_normed = 2.0 * vmap1_smoothed / unitcell_volume
+    vmap1_smoothed_normed_offset = (
+        vmap1_smoothed_normed - vmap1_smoothed_normed.min() + 1e-3
+    )
+
+    variance2_map = map2_normed * map2_normed
+    Fvmap2 = map2fourier(variance2_map, HKL_arrays)
+    Fvmap2_smoothed = Fvmap2 * Rg
+    vmap2_smoothed = fourier2map(Fvmap2_smoothed, HKL_arrays, gridsize)
+    vmap2_smoothed_normed = 2.0 * vmap2_smoothed / unitcell_volume
+    vmap2_smoothed_normed_offset = (
+        vmap2_smoothed_normed - vmap2_smoothed_normed.min() + 1e-3
+    )
+
+    ccmap = (productmap_smooth_norm - productmap_smooth_norm.mean()) / torch.sqrt(
+        vmap1_smoothed_normed_offset * vmap2_smoothed_normed_offset
+    )
+    return ccmap.cpu().numpy()
+
+
+def get_b_from_CC(CC_values, d_min):
+    # Truncate very small or negative CC values
+    CC_trunc = (CC_values + 0.001 + np.abs(CC_values - 0.001)) / 2
+
+    # Flex arrays can't be used as exponents, so work around this with logs
+    u1 = np.exp(np.log(0.188779) * CC_trunc)
+    u2 = np.exp(2.21742 * CC_trunc * np.log(CC_trunc))
+    u3 = np.exp(0.777046 * np.tan(CC_trunc) * np.log(CC_trunc) * CC_trunc)
+    b_values_from_CC = (
+        np.power(d_min, 2) * 134.024 * np.power(0.213624 - u1 * u2 - 0.359452 * u3, 2)
+    )
+    # Truncate B-values at a maximum of 350 above minimum
+    # 350 was chosen semi-arbitrarily as a point at which the sigmaA curve drops
+    # below 0.1 at 6A, so that data beyond 6A will have little influence
+    bmax = np.min(b_values_from_CC) + 350.0
+    b_values_from_CC = (b_values_from_CC + bmax - np.abs(b_values_from_CC - bmax)) / 2
+    return b_values_from_CC

--- a/test/unit/test_cryo_structurefactors.py
+++ b/test/unit/test_cryo_structurefactors.py
@@ -18,8 +18,8 @@ class DummyCryoSFCalc:
         # Return dummy normalized value
         return torch.tensor([1.0])
 
-    def get_scales_adam(self):
-        self.called.append("get_scales_adam")
+    def get_scales_adam(self, sub_ratio=1.0):
+        self.called.append(("get_scales_adam", sub_ratio))
 
 
 @pytest.fixture(autouse=True)
@@ -47,8 +47,7 @@ def test_initial_cryoSFC_sets_attributes():
     # Should be three calls
     assert len(called) == 3
     assert called[0] == "calc_fprotein"
-    assert called[2] == "get_scales_adam"
-    # The middle call is ('calc_Ec', tensor)
+    assert called[2] == ("get_scales_adam", 1.0)
     name, tensor_arg = called[1]
     assert name == "calc_Ec"
     assert torch.allclose(tensor_arg, torch.tensor([5.0]))

--- a/test/unit/test_refinement_utils.py
+++ b/test/unit/test_refinement_utils.py
@@ -433,7 +433,7 @@ def test_init_bias(mock_adamw, mock_adam):
 
 
 @patch("rocket.coordinates.extract_allatoms")
-@patch("rocket.coordinates.weighted_kabsch")
+@patch("rocket.coordinates.iterative_kabsch_alignment")
 @patch("rocket.utils.plddt2pseudoB_pt")
 @patch("rocket.utils.weighting")
 @patch("rocket.utils.assert_numpy")
@@ -504,7 +504,7 @@ def test_position_alignment(
 
 
 @patch("rocket.coordinates.extract_allatoms")
-@patch("rocket.coordinates.weighted_kabsch")
+@patch("rocket.coordinates.iterative_kabsch_alignment")
 @patch("rocket.utils.plddt2pseudoB_pt")
 @patch("rocket.utils.weighting")
 @patch("rocket.utils.assert_numpy")


### PR DESCRIPTION
This is a PR for a new feature: supporting the construction of B-factors using fast RSCC calculations on the fly. We reference Randy’s code and implement all necessary functions using SFC, NumPy, and PyTorch.

In short: we now have a fast local RSCC calculation that can be used on the fly, **adding only about 0.05 s per ROCKET** iteration since Fcalc already needs to be computed for each proposed model.

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/5c262134-cb0b-47c0-98c8-75a579fb4929" />

In the thread below, I discuss the detailed algorithms and compare every intermediate result between our re‐implementation and Randy’s cctbx code.

---

Overall, the pipeline comprises eight steps as illustrated in the plots below. Dashed boxes denote variables in reciprocal space, and solid boxes denote variables in real space. As you can tell a lot of FFT back and forth.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/aacc03c4-5a96-4174-ba19-b19a0b9f3a48" />

---

**Step 1: Generate structural factors from the model coordinates. Our results using SFC—considering only Fprotein—are perfectly consistent with the intermediate results in Randy’s code.**

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/bc2974ef-1706-4bc5-a81f-ac7397b261a3" />

---

**Step 2: Convert Fourier coefficients into real-space maps by simple gridding and FFT, perfect alignment with Randy’s results.**

<img width="800" alt="image" src="https://github.com/user-attachments/assets/1f36d690-b50f-4742-be52-c28c8a502424" />

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/b9574539-ac64-4d70-be9b-8a43da2bbc27" />

---

**Step 3: Convert the local product map into Fourier coefficients, taking extra care with gridding and FFT ordering, which we have handled correctly.**

<img width="800" alt="image" src="https://github.com/user-attachments/assets/23c05410-d075-4fe6-a3cc-fd498d1d73d1" />

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/43fe411c-f3a3-44e0-8446-f0855ee20da1" />


---

**Step 4-5: Using a spherical filter to enforce local smoothness by performing the operation in Fourier space via the convolution theorem, significantly reducing computational cost.**

<img width="800" alt="image" src="https://github.com/user-attachments/assets/90ed1c50-51e2-43ca-978f-7809dcaafbc8" />

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/10517eff-38c2-4599-88ae-9cf06c6108bf" />

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/fa7f6259-2987-484e-9d19-ef2ed8484d5c" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/420da525-31c7-431c-8c2c-ae9faff851c4" />

**Note: although they are perfectly correlated, there is somehow an offset in the smoothed product map, which seems tiny but will make the correlation map quite different, which you will see in the following**

---

**Step 6: Intuitively a simple step—compute the ccmap using the maps obtained above. However, small offsets in the product maps translate to intensity differences in the background, causing the ccmap to vary significantly in those regions.**

**Note: Those background signals' difference aren’t crucial for our results—since in the next step we’ll interpolate values only at the atomic positions—but it would still be helpful to understand the cause and fix it.**

<img width="800" alt="image" src="https://github.com/user-attachments/assets/199c755b-813c-46c3-8c5d-27f5b9f98a1a" />

If we know and remove that offset in the product map, the ccmap will be perfectly aligned again, but we it is hard to estimate what the offset is:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/07b16fed-c4e8-40c5-95ad-ff6325e5e4ec" />

Thus, in the current codebase we subtract the product map means before calculating the CC map:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/5f55e1b8-7cd8-4120-bdc5-fab7e25127a7" />

 ---

**Step 7: Interpolating the map values at the atomic coordinates regions, we got good correlation with Randy's results**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/068ecbf0-e076-44d6-88c7-9e3d9759c23e" />

Scipy’s implementation of linear interpolation is quite fast. It also supports nearest and cubic methods, with cubic being the slowest.

---

**Step 8: Convert the atomic RSCC to atomic B-factors using Randy’s empirical equations; this is trivial to implement. Results are good enough for me.**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/1767f28a-7025-488a-867c-1be0d15cf14b" />



 
