### PR TITLE
make the added chain for xray more robust and easy to use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [ # Optional: PyPI classifiers, see https://pypi.org/classifiers/
 ]
 
 dependencies = [
-    "scikit-bio",
+    "scikit-bio<=0.6.3",
     "loguru",
     "SFcalculator-torch>=0.2.2",
     "matplotlib",

--- a/rocket/refinement_config.py
+++ b/rocket/refinement_config.py
@@ -68,6 +68,7 @@ class FeatureFlags(BaseModel):
     sfc_scale: bool = True
     refine_sigmaA: bool = True
     additional_chain: bool = False
+    total_chain_copy: float = 1.0
     bias_from_fullmsa: bool = False
     chimera_profile: bool = False
 
@@ -167,6 +168,7 @@ class RocketRefinmentConfig(BaseModel):
         "sfc_scale": "algorithm.features.sfc_scale",
         "refine_sigmaA": "algorithm.features.refine_sigmaA",
         "additional_chain": "algorithm.features.additional_chain",
+        "total_chain_copy": "algorithm.features.total_chain_copy",
         "bias_from_fullmsa": "algorithm.features.bias_from_fullmsa",
         "chimera_profile": "algorithm.features.chimera_profile",
         # Data

--- a/rocket/refinement_xray.py
+++ b/rocket/refinement_xray.py
@@ -103,10 +103,10 @@ def run_xray_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmentC
         )
         sfc_added_chain.calc_fprotein()
         constant_fp_added_HKL = (
-            sfc_added_chain.Fprotein_HKL.clone().detach().to(device=device)
+            sfc_added_chain.Fprotein_HKL.clone().detach()
         )
         constant_fp_added_asu = (
-            sfc_added_chain.Fprotein_asu.clone().detach().to(device=device)
+            sfc_added_chain.Fprotein_asu.clone().detach()
         )
         del sfc_added_chain
 

--- a/rocket/refinement_xray.py
+++ b/rocket/refinement_xray.py
@@ -102,12 +102,8 @@ def run_xray_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmentC
             device=device,
         )
         sfc_added_chain.calc_fprotein()
-        constant_fp_added_HKL = (
-            sfc_added_chain.Fprotein_HKL.clone().detach()
-        )
-        constant_fp_added_asu = (
-            sfc_added_chain.Fprotein_asu.clone().detach()
-        )
+        constant_fp_added_HKL = sfc_added_chain.Fprotein_HKL.clone().detach()
+        constant_fp_added_asu = sfc_added_chain.Fprotein_asu.clone().detach()
         del sfc_added_chain
 
         phitrue_path = f"{config.path}/ROCKET_inputs/{config.file_id}_allchains-phitrue-solvent{config.solvent}.npy"  # noqa: E501

--- a/rocket/xtal/structurefactors.py
+++ b/rocket/xtal/structurefactors.py
@@ -20,6 +20,7 @@ def initial_SFC(
     solvent=True,
     added_chain_HKL=None,
     added_chain_asu=None,
+    total_chain_copy=1.0,
     spacing=4.5,
 ):
     if device is None:
@@ -41,7 +42,7 @@ def initial_SFC(
     if added_chain_HKL is not None:
         sfcalculator.Fprotein_HKL = sfcalculator.Fprotein_HKL + added_chain_HKL
         sfcalculator.Fprotein_asu = sfcalculator.Fprotein_asu + added_chain_asu
-        sfcalculator.solventpct = 1 - (1 - sfcalculator.solventpct) * 2
+        sfcalculator.solventpct = 1 - (1 - sfcalculator.solventpct) * total_chain_copy
 
     if solvent:
         sfcalculator.calc_fsolvent()

--- a/test/unit/test_xtal_structurefactors.py
+++ b/test/unit/test_xtal_structurefactors.py
@@ -62,6 +62,7 @@ def test_initial_SFC_added_chain():
         "SigF",
         added_chain_HKL=torch.tensor([2.0]),
         added_chain_asu=torch.tensor([3.0]),
+        total_chain_copy=2.0,
     )
     assert torch.allclose(result.Fprotein_HKL, torch.tensor([3.0]))  # 1 + 2
     assert torch.allclose(result.Fprotein_asu, torch.tensor([4.0]))  # 1 + 3


### PR DESCRIPTION
I’ve enhanced the “added chain” feature for X-ray cases to make it more robust, also more user-friendly. 

Users now only need to place a file named `{file_id}_added_chain.pdb`—which includes all other fixed chains—in the `ROCKET_inputs` folder. The pipeline will compute the structure factors on the fly.

I’ve also resolved issue #53 by introducing a new `total_chain_copy` argument.
