### PR TITLE
Issue #52

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,7 @@ dependencies = [
     "polyleven",
     "scikit-learn",
     "seaborn",
-    # MDTraj + HDF5 support for writing trajectories
     "mdtraj",
-    "h5py",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fix issue #52 

- Replace per-iteration PDB clutter with one multi-model PDB per run: <run_id>_refinement_trajectory.pdb.
- Append frames each iteration, using topology from input_pdb.
- Flush + fsync after each write so already-written frames remain readable if the run crashes.
- Save final best model as a single PDB: best_model_<best_run>_<best_iter>.pdb.
- Fallback: if mdtraj unavailable, preserve original per-iteration PDB saves.
- Kept X-ray and cryo-EM pipelines consistent.