### PR TITLE
Issue#57

### DIFF
--- a/rocket/refinement_config.py
+++ b/rocket/refinement_config.py
@@ -31,6 +31,7 @@ class DATAMODE(StrEnum):
 class PathConfig(BaseModel):
     path: str = ""
     file_id: str = ""
+    input_pdb: str = ""
     template_pdb: str | None = None
     input_msa: str | None = None
     sub_msa_path: str | None = None
@@ -135,6 +136,7 @@ class RocketRefinmentConfig(BaseModel):
         # Paths
         "path": "paths.path",
         "file_id": "paths.file_id",
+        "input_pdb": "paths.input_pdb",
         "template_pdb": "paths.template_pdb",
         "input_msa": "paths.input_msa",
         "sub_msa_path": "paths.sub_msa_path",
@@ -324,6 +326,9 @@ def gen_config_phase1(datamode: DATAMODE, working_dir: str, file_id: str):
         paths=PathConfig(
             path=working_dir,
             file_id=file_id,
+            input_pdb=os.path.join(
+                working_dir, "ROCKET_inputs", f"{file_id}-pred-aligned.pdb"
+            ),  # noqa: E501
             uuid_hex=uuid.uuid4().hex[:10],
         ),
         execution=ExecutionConfig(
@@ -358,9 +363,11 @@ def gen_config_phase2(phase1_config: RocketRefinmentConfig):
         phase2_config.path, "ROCKET_outputs", phase2_config.uuid_hex
     )
     phase1_path = os.path.join(output_directory_path, phase1_config.note)
+    input_pdb_path = os.path.join(phase1_path, "best_model_*_*.pdb")
     starting_bias_path = os.path.join(phase1_path, "best_msa_bias*.pt")
     starting_weights_path = os.path.join(phase1_path, "best_feat_weights*.pt")
 
+    phase2_config.paths.input_pdb = input_pdb_path
     phase2_config.paths.starting_bias = starting_bias_path
     phase2_config.paths.starting_weights = starting_weights_path
     if phase1_config.input_msa is not None:

--- a/rocket/refinement_cryoem.py
+++ b/rocket/refinement_cryoem.py
@@ -45,7 +45,10 @@ def run_cryoem_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmen
     target_id = config.file_id
     path = config.path
     mtz_file = f"{path}/ROCKET_inputs/{target_id}-Edata.mtz"
-    input_pdb = config.input_pdb
+    try:
+        input_pdb = glob.glob(config.input_pdb)[0]
+    except Exception as err:
+        raise ValueError("input_pdb path is not valid!") from err
     note = config.note
     bias_version = config.bias_version
     iterations = config.iterations

--- a/rocket/refinement_xray.py
+++ b/rocket/refinement_xray.py
@@ -43,7 +43,10 @@ def run_xray_refinement(config: RocketRefinmentConfig | str) -> RocketRefinmentC
 
     # Configure input paths
     tng_file = f"{config.path}/ROCKET_inputs/{config.file_id}-Edata.mtz"
-    input_pdb = config.input_pdb
+    try:
+        input_pdb = glob.glob(config.input_pdb)[0]
+    except Exception as err:
+        raise ValueError("input_pdb path is not valid!") from err
 
     # Configure output path
     # Generate uuid for this run


### PR DESCRIPTION
This pull request updates the refinement pipeline to improve input PDB file handling and streamline the X-ray refinement process. The main changes include introducing flexible input PDB path configuration, updating how input PDB files are located and loaded, and removing unused reference PDB logic from the X-ray refinement code.

**Input PDB handling improvements:**

* Added an `input_pdb` field to the `PathConfig` and updated configuration mapping to support flexible input PDB paths. [[1]](diffhunk://#diff-fbe7014f84de4bc0f8b7ea59880b5381f0ed21768d7a2322e652b81d568d6102R34) [[2]](diffhunk://#diff-fbe7014f84de4bc0f8b7ea59880b5381f0ed21768d7a2322e652b81d568d6102R139)
* In both phase 1 and phase 2 config generation (`gen_config_phase1`, `gen_config_phase2`), set `input_pdb` to the correct path or glob pattern for later use. [[1]](diffhunk://#diff-fbe7014f84de4bc0f8b7ea59880b5381f0ed21768d7a2322e652b81d568d6102R329-R331) [[2]](diffhunk://#diff-fbe7014f84de4bc0f8b7ea59880b5381f0ed21768d7a2322e652b81d568d6102R366-R370)
* Updated `run_cryoem_refinement` and `run_xray_refinement` to find the input PDB file using a glob pattern from the config, raising an error if not found, instead of relying on a fixed path. [[1]](diffhunk://#diff-c4330751747f2decc9b21f1841c91f0b876eba0fbd9418a5ce789a423e3b330fL48-R51) [[2]](diffhunk://#diff-5a2161f790cef3579f9ef2e0f435fb16351de5a397405c6fc9517c87d49b9d21L46-R49)

**X-ray refinement code simplification:**

* Removed all logic and tracking related to the reference PDB (`true_pdb`), including existence checks, residue MSE loss calculation, and saving per-iteration MSE loss. This streamlines the code and removes unused features. [[1]](diffhunk://#diff-5a2161f790cef3579f9ef2e0f435fb16351de5a397405c6fc9517c87d49b9d21L72-L74) [[2]](diffhunk://#diff-5a2161f790cef3579f9ef2e0f435fb16351de5a397405c6fc9517c87d49b9d21L148-L150) [[3]](diffhunk://#diff-5a2161f790cef3579f9ef2e0f435fb16351de5a397405c6fc9517c87d49b9d21L171-L175) [[4]](diffhunk://#diff-5a2161f790cef3579f9ef2e0f435fb16351de5a397405c6fc9517c87d49b9d21L397) [[5]](diffhunk://#diff-5a2161f790cef3579f9ef2e0f435fb16351de5a397405c6fc9517c87d49b9d21L522-L527) [[6]](diffhunk://#diff-5a2161f790cef3579f9ef2e0f435fb16351de5a397405c6fc9517c87d49b9d21L740-L746)

**Other minor improvements:**

* RSCC Bfactor initialization in cryo-EM refinement is now conditional on phase1, preventing unnecessary computation in other phases.