### PR TITLE
feat, add pypi badge to readme, update installation tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # *R*efining *O*penfold predictions with *C*rystallographic/*C*ryo-EM Li*KE*lihood *T*argets (ROCKET)
 
+![PyPI - Version](https://img.shields.io/pypi/v/rs-rocket)
 [![Build](https://github.com/alisiafadini/ROCKET/actions/workflows/test.yml/badge.svg)](https://github.com/alisiafadini/ROCKET/actions/workflows/test.yml)
 [![Ruff](https://github.com/alisiafadini/ROCKET/actions/workflows/lint.yml/badge.svg)](https://github.com/alisiafadini/ROCKET/actions/workflows/lint.yml)
 [![GitHub License](https://img.shields.io/github/license/alisiafadini/ROCKET)](https://github.com/alisiafadini/ROCKET/blob/main/LICENSE)
@@ -15,7 +16,8 @@ You can find detailed documentation and walk-through tutorials at: https://rocke
 
 ## Installation
 
-### 1. Install OpenFold
+<details>
+<summary><span style="font-size:1.3em;font-weight:bold;">1. Install OpenFold</span></summary>
 
 To ensure usability, we forked the OpenFold repo, and sorted a couple details in the installation guides. Here is what we advise ROCKET users to do:
 
@@ -109,7 +111,12 @@ To ensure usability, we forked the OpenFold repo, and sorted a couple details in
     OK (skipped=41)
     ```   
 
-### 2. Install Phenix (required from automatic preprocessing and post-refinement)
+</details>
+
+
+
+<details>
+<summary><span style="font-size: 1.3em; font-weight: bold;">2. Install Phenix (required for automatic preprocessing and post-refinement)</span></summary>
 
 [Phenix](https://phenix-online.org/) is required for automatic data preprocessing and for post-refinement when polishing final model geometry. Follow the steps below to install it and **add the path to the system environment variables**:
 
@@ -144,25 +151,26 @@ To ensure usability, we forked the OpenFold repo, and sorted a couple details in
     echo $PHENIX_ROOT 
     ``` 
 
+</details>
+
+
+
 ### 3. Install ROCKET
 
-Install ROCKET. First move to the parent folder, clone the ROCKET repo (so you don't mix the ROCKET repo with the OpenFold one), then install it with `pip`
+ROCKET is available through pypi as `rs-rocket`, you can easily install by run
+
+```
+pip install rs-rocket
+```
+
+For developer mode, you can fetch the repo and do editable installation locally 
 
 ```
 git clone https://github.com/alisiafadini/ROCKET.git
 cd ROCKET
-pip install .
+pip install -e ".[tests,CI]"
 ```
 
-It will automatically install dependencies like `SFcalculator` and `reciprocalspaceship`.
-
-Note: If you get errors about incompatibility of `prompt_toolkit`, ignore them.
-
-For develop mode, run
-
-```
-pip install -e .
-```
 
 Run `rk.score --help` after installation, if you see a normal doc strings without errors, you are good to go!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,6 @@ CI = [
     "pre-commit",
 ]
 
-openfold = [
-    "openfold",
-]
-xtal = [
-    "SFcalculator-torch>=0.2.2",
-]
-
 [project.urls]
 Homepage = "https://github.com/alisiafadini/ROCKET"
 Repository = "https://github.com/alisiafadini/ROCKET"


### PR DESCRIPTION
This pull request updates the `README.md` to improve the installation instructions and adds a PyPI version badge. The main changes focus on making the installation process clearer and more user-friendly, especially for new users, and on simplifying the installation of dependencies.

Documentation improvements:

* Added a PyPI version badge to the top of the `README.md` to indicate the current version available on PyPI.
* Refactored the installation instructions by wrapping the OpenFold and Phenix installation steps in collapsible `<details>` sections for better readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R119)
* Updated the ROCKET installation step to recommend installing via `pip install rs-rocket` from PyPI, making the process simpler and more standard. Also clarified instructions for developer (editable) installations.

Dependency management:

* Removed the `openfold` and `xtal` (SFcalculator-torch) optional dependency groups from `pyproject.toml`, as these are now handled automatically or are no longer needed as separate install targets.