### PR TITLE
feat: adjust default LRs for low-res cryoEM and phase2

### DIFF
--- a/notebooks/RSCC_plot.ipynb
+++ b/notebooks/RSCC_plot.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "883a037f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rocket/refinement_config.py
+++ b/rocket/refinement_config.py
@@ -59,7 +59,7 @@ class OptimizationParams(BaseModel):
     rbr_opt_algorithm: str = "lbfgs"
     rbr_lbfgs_learning_rate: float = 150.0
     smooth_stage_epochs: int | None = 50
-    phase2_final_lr: float = 1e-3
+    phase2_final_lr: float = 1e-4
     l2_weight: float = 1e-7
 
 
@@ -380,7 +380,7 @@ def gen_config_phase1(
                 additive_learning_rate=0.05,
                 multiplicative_learning_rate=1.0,
                 l2_weight=1e-7,
-                phase2_final_lr=1e-3,
+                phase2_final_lr=1e-4,
                 smooth_stage_epochs=50,
             ),
         ),

--- a/rocket/scripts/run_preprocess.py
+++ b/rocket/scripts/run_preprocess.py
@@ -503,7 +503,17 @@ def cli_runpreprocess():
     phase1_config.algorithm.init_recycling = args.max_recycling_iters
 
     # Use smaller learning rates for low-resolution cryoEM data (> 5 Å)
-    if args.method == "cryoem" and float(args.resolution) > 5.0:
+    resolution_value = None
+    if args.resolution is not None:
+        try:
+            resolution_value = float(args.resolution)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid resolution value '{}' provided; skipping resolution-based "
+                "learning rate adjustment.",
+                args.resolution,
+            )
+    if args.method == "cryoem" and resolution_value is not None and resolution_value > 5.0:
         logger.info(
             f"Low-resolution cryoEM ({args.resolution} Å): setting lr_a=1e-4, lr_m=1e-3"
         )

--- a/rocket/scripts/run_preprocess.py
+++ b/rocket/scripts/run_preprocess.py
@@ -501,6 +501,15 @@ def cli_runpreprocess():
         use_deepspeed_evo_attention=args.use_deepspeed_evoformer_attention,
     )
     phase1_config.algorithm.init_recycling = args.max_recycling_iters
+
+    # Use smaller learning rates for low-resolution cryoEM data (> 5 Å)
+    if args.method == "cryoem" and float(args.resolution) > 5.0:
+        logger.info(
+            f"Low-resolution cryoEM ({args.resolution} Å): setting lr_a=1e-4, lr_m=1e-3"
+        )
+        phase1_config.algorithm.optimization.additive_learning_rate = 1e-4
+        phase1_config.algorithm.optimization.multiplicative_learning_rate = 1e-3
+
     if seg_id:
         phase1_config.algorithm.domain_segs = seg_id
     phase1_config.to_yaml_file(

--- a/rocket/scripts/run_preprocess.py
+++ b/rocket/scripts/run_preprocess.py
@@ -513,7 +513,12 @@ def cli_runpreprocess():
                 "learning rate adjustment.",
                 args.resolution,
             )
-    if args.method == "cryoem" and resolution_value is not None and resolution_value > 5.0:
+    is_low_res_cryoem = (
+        args.method == "cryoem"
+        and resolution_value is not None
+        and resolution_value > 5.0
+    )
+    if is_low_res_cryoem:
         logger.info(
             f"Low-resolution cryoEM ({args.resolution} Å): setting lr_a=1e-4, lr_m=1e-3"
         )


### PR DESCRIPTION
Low resolution cryo-EM is more sensitive to high LR. As we find a more principled approach, we have this temporary fix:

- When cryoEM resolution > 5 Å, set phase1 `lr_a=1e-4`, `lr_m=1e-3`
- Change default `phase2_final_lr` from `1e-3` to `1e-4` for all cases